### PR TITLE
rename API option 'template' to 'renderItem'.

### DIFF
--- a/packages/lit-virtualizer/CHANGELOG.md
+++ b/packages/lit-virtualizer/CHANGELOG.md
@@ -3,5 +3,8 @@
 - `scrollToIndex` method on `<lit-virtualizer>`.
 - `scrollToIndex` configuration option on `scroll` directive.
 
+### Changed
+- Renamed API option `template` to `renderItem`.
+
 ## [0.1.0] - 2019-06-05
 - Initial prerelease.

--- a/packages/lit-virtualizer/README.md
+++ b/packages/lit-virtualizer/README.md
@@ -73,7 +73,7 @@ Other small chunks will also be present. Lit-virtualizer utilizes [dynamic impor
 
 ### `scroll` directive
 
-`scroll` is a lit-html directive that turns its parent element into a virtual scrolling area. It requires a template for rendering virtual children, and an array of items for populating the template.
+`scroll` is a lit-html directive that turns its parent element into a virtual scrolling area. It requires a `renderItem` function for rendering virtual children, and an array of items to render.
 
 Say we are building an index page for a blog, and need a list of link to all blog posts. The blog has thousands of posts, so we want the list to have virtual scrolling. Here's our index.html...
 ```html
@@ -98,20 +98,20 @@ const posts = [
 ];
 
 // Building our post link template.
-// A template is a function that takes an item (our metadata)
+// renderPostLink is a function that takes an item (our metadata)
 // and uses the `html` tag to build DOM structure with it.
-const postLinkTemplate = post => html`
+const renderPostLink = post => html`
   <div>
     <h2><a href="${post.link}">${post.title}</a></h2>
     <p>${post.date}</p>
   </div>
 `;
 
-// Pass the post metadata and the template to the scroll directive...
+// Pass the post metadata and the render to the scroll directive...
 const templateResult = html`${
   scroll({
     items: posts,
-    template: postLinkTemplate
+    renderItem: renderPostLink
   })
 }`
 
@@ -119,7 +119,7 @@ const templateResult = html`${
 render(templateResult, document.querySelector("#post-list"));
 ```
 
-In this example, just `items` and `template` were configured. You can also specify the scroll target and whether or not to use shadow DOM.
+In this example, just `items` and `renderItem` were configured. You can also specify the scroll target and whether or not to use shadow DOM.
 
 
 
@@ -129,9 +129,9 @@ In this example, just `items` and `template` were configured. You can also speci
 
 Type: `Array<T>`
 
-A list of items to display via the template function. The type of the items should match the first argument of the template function.
+A list of items to display via the renderItem function. The type of the items should match the first argument of the renderItem function.
 
-#### `template`
+#### `renderItem`
 
 Type: `(item: T, index?: number) => lit-html.TemplateResult`
 
@@ -163,7 +163,7 @@ where position is: `'start'|'center'|'end'|'nearest'`
 
 Optional. Scroll to the item at the give index. Place the item at the given position within the scroll view. For example, if index is `100` and position is `end`, then the bottom of the item at index 100 will be at the bottom of the scroll view. Position defaults to `start`.
 
-Note: Rendering with `scrollToIndex` will cause the scroll view to fix at the given position until the user manually scrolls. If a template using the `scroll` directive is re-rendered, note that the view will be re-scrolled to respect the given `scrollToIndex` option. Take care to set or unset the `scrollToIndex` option upon subsequent re-renders for the desired behavior.
+Note: Rendering with `scrollToIndex` will cause the scroll view to fix at the given position until the user manually scrolls. If a lit-html template using the `scroll` directive is re-rendered, note that the view will be re-scrolled to respect the given `scrollToIndex` option. Take care to set or unset the `scrollToIndex` option upon subsequent re-renders for the desired behavior.
 
 ---
 
@@ -177,7 +177,7 @@ Here's how to redo the blog post example, using `<lit-virtualizer>` instead. Con
 const templateResult = html`
   <lit-virtualizer
     .items=${posts}
-    .template=${postLinkTemplate}
+    .renderItem=${renderPostLink}
   ></lit-virtualizer>
 `
 render(templateResult, document.querySelector("#post-list"));
@@ -191,9 +191,9 @@ With `<lit-virtualizer>`, you pass configuration as properties to the HTML Eleme
 
 Type: `Array<T>`
 
-A list of items to display via the template function. The type of the items should match the first argument of the template function.
+A list of items to display via the renderItem function. The type of the items should match the first argument of the renderItem function.
 
-#### `template` property
+#### `renderItem` property
 
 Type: `(item: T, index?: number) => lit-html.TemplateResult`
 
@@ -218,7 +218,7 @@ Example usage:
 ```ts
 const virtualizer = document.createElement('lit-virtualizer');
 virtualizer.items = contacts;
-virtualizer.template = contactTemplate;
+virtualizer.renderItem = renderContactItem;
 // Scroll to the 100th item and put it in the center of the scroll view.
 virtualizer.scrollToIndex(100, 'center');
 ```
@@ -262,7 +262,7 @@ class ContactList extends LitElement {
             <lit-virtualizer
               .scrollTarget=${window}
               .items=${this.data}
-              .template=${(contact) => html`
+              .renderItem=${(contact) => html`
                 <div><b>${contact.name}</b>: ${contact.phone}</div>
               `}>
             </lit-virtualizer>

--- a/packages/lit-virtualizer/src/lib/lit-virtualizer.ts
+++ b/packages/lit-virtualizer/src/lib/lit-virtualizer.ts
@@ -11,7 +11,7 @@ import { scroll } from './scroll';
 @customElement('lit-virtualizer')
 export class LitVirtualizer extends LitElement {
     @property()
-    _renderItem: (item: any, index?: number) => TemplateResult;
+    private _renderItem: (item: any, index?: number) => TemplateResult;
 
     @property()
     items: Array<any>;

--- a/packages/lit-virtualizer/src/lib/lit-virtualizer.ts
+++ b/packages/lit-virtualizer/src/lib/lit-virtualizer.ts
@@ -5,13 +5,13 @@ import { scroll } from './scroll';
  * A LitElement wrapper of the scroll directive.
  * 
  * Import this module to declare the lit-virtualizer custom element.
- * Pass an items array, template, and scroll target as properties to the
- * <lit-virtualizer> element.
+ * Pass an items array, renderItem method, and scroll target as properties
+ * to the <lit-virtualizer> element.
  */
 @customElement('lit-virtualizer')
 export class LitVirtualizer extends LitElement {
     @property()
-    _template: (item: any, index?: number) => TemplateResult;
+    _renderItem: (item: any, index?: number) => TemplateResult;
 
     @property()
     items: Array<any>;
@@ -27,14 +27,14 @@ export class LitVirtualizer extends LitElement {
     }
 
     /**
-     * The template used for rendering each item.
+     * The method used for rendering each item.
      */
-    get template() {
-        return this._template;
+    get renderItem() {
+        return this._renderItem;
     }
-    set template(template) {
-        if (template !== this.template) {
-            this._template = template;
+    set renderItem(renderItem) {
+        if (renderItem !== this.renderItem) {
+            this._renderItem = renderItem;
             this.requestUpdate();
         }
     }
@@ -53,7 +53,7 @@ export class LitVirtualizer extends LitElement {
     render(): TemplateResult {
         return html`${scroll({
             items: this.items,
-            template: this._template,
+            renderItem: this._renderItem,
             scrollTarget: this.scrollTarget,
             scrollToIndex: this._scrollToIndex,
             // TODO: enable this flag.

--- a/packages/lit-virtualizer/src/lib/repeat.ts
+++ b/packages/lit-virtualizer/src/lib/repeat.ts
@@ -15,7 +15,7 @@ export const LitMixin = Superclass => class extends Superclass {
   _pool: Array<NodePart>;
 
   // Method for generating each item's DOM.
-  _template: (item: any, index?: number) => TemplateResult;
+  _renderItem: (item: any, index?: number) => TemplateResult;
 
   // Children are rendered into this part.
   // The host of the directive that constructs the scroller.
@@ -29,18 +29,18 @@ export const LitMixin = Superclass => class extends Superclass {
    */
   constructor(config: {
     part: NodePart,
-    template: (item: any, index?: number) => TemplateResult,
+    renderItem: (item: any, index?: number) => TemplateResult,
     useShadowDOM?: boolean,
     scrollTarget?: Element | Window,
     layout?: Layout
   }) {
-    const {part, template, useShadowDOM, layout} = config;
+    const {part, renderItem, useShadowDOM, layout} = config;
     let container = part.startNode.parentNode;
     let scrollTarget = config.scrollTarget || container;
     super({container, scrollTarget, useShadowDOM, layout});
 
     this._pool = [];
-    this._template = template;
+    this._renderItem = renderItem;
     this._hostPart = part;
   }
 
@@ -49,7 +49,7 @@ export const LitMixin = Superclass => class extends Superclass {
   }
 
   updateElement(part: NodePart, item, idx: number) {
-    part.setValue(this._template(item, idx));
+    part.setValue(this._renderItem(item, idx));
     part.commit();
   }
 
@@ -123,7 +123,7 @@ export const LitMixin = Superclass => class extends Superclass {
 export const LitRepeater = LitMixin(VirtualRepeater);
 
 interface RepeatConfig {
-  template: (item: any, index?: number) => TemplateResult,
+  renderItem: (item: any, index?: number) => TemplateResult,
   part: NodePart,
   first?: number,
   num?: number,
@@ -139,7 +139,7 @@ export const repeat = directive((config: RepeatConfig) => async (part: NodePart)
     if (!part.startNode.isConnected) {
       await Promise.resolve();
     }
-    repeater = new LitRepeater({part, template: config.template});
+    repeater = new LitRepeater({part, renderItem: config.renderItem});
     partToRepeater.set(part, repeater);
   }
   const {first, num, totalItems} = config;

--- a/packages/lit-virtualizer/src/lib/scroll.ts
+++ b/packages/lit-virtualizer/src/lib/scroll.ts
@@ -15,7 +15,7 @@ const partToScroller: WeakMap<NodePart, any> = new WeakMap();
 interface ScrollConfig {
   // A function that returns a lit-html TemplateResult. It will be used
   // to generate the DOM for each item in the virtual list.
-  template?: (item: any, index?: number) => TemplateResult,
+  renderItem?: (item: any, index?: number) => TemplateResult,
 
   layout?: Layout,
 
@@ -25,7 +25,7 @@ interface ScrollConfig {
   // Whether to build the virtual scroller within a shadow DOM.
   useShadowDOM?: boolean,
 
-  // The list of items to display via the template function.
+  // The list of items to display via the renderItem function.
   items?: Array<any>,
 
   // Limit for the number of items to display. Defaults to the length
@@ -49,8 +49,8 @@ export const scroll = directive((config: ScrollConfig = {}) => async (part: Node
     if (!part.startNode.isConnected) {
       await Promise.resolve();
     }
-    let {template, layout, scrollTarget, useShadowDOM} = config;
-    scroller = new LitScroller({part, template, layout, scrollTarget, useShadowDOM});
+    let {renderItem, layout, scrollTarget, useShadowDOM} = config;
+    scroller = new LitScroller({part, renderItem, layout, scrollTarget, useShadowDOM});
     partToScroller.set(part, scroller);
   }
   Object.assign(scroller, {

--- a/packages/lit-virtualizer/test/benchmarks/basic.html
+++ b/packages/lit-virtualizer/test/benchmarks/basic.html
@@ -12,7 +12,7 @@
       <section>
           ${scroll({
               items: arr,
-              template: (num) => html`<p>${num}</p>`,
+              renderItem: (num) => html`<p>${num}</p>`,
               scrollTarget: window,
               useShadowDOM: false
           })}

--- a/packages/lit-virtualizer/test/benchmarks/useShadowDOM.html
+++ b/packages/lit-virtualizer/test/benchmarks/useShadowDOM.html
@@ -12,7 +12,7 @@
       <section>
           ${scroll({
               items: arr,
-              template: (num) => html`<p>${num}</p>`,
+              renderItem: (num) => html`<p>${num}</p>`,
               scrollTarget: window,
               useShadowDOM: true
           })}

--- a/packages/lit-virtualizer/test/screenshot/cases/lit-virtual/main.js
+++ b/packages/lit-virtualizer/test/screenshot/cases/lit-virtual/main.js
@@ -6,7 +6,7 @@ import { html } from 'lit-html';
 
   const virtualizer = document.createElement('lit-virtualizer');
   virtualizer.items = contacts;
-  virtualizer.template = ({ mediumText }) => html`<p>${mediumText}</p>`;
+  virtualizer.renderItem = ({ mediumText }) => html`<p>${mediumText}</p>`;
 
   document.body.appendChild(virtualizer);
 })();

--- a/packages/lit-virtualizer/test/screenshot/cases/scroll/main.js
+++ b/packages/lit-virtualizer/test/screenshot/cases/scroll/main.js
@@ -11,7 +11,7 @@ import { html, render } from 'lit-html';
   const virtualized = html`<div id="main">
     ${scroll({
       items: contacts,
-      template: ({ mediumText }, i) => html`<p>${i}) ${mediumText}</p>`,
+      renderItem: ({ mediumText }, i) => html`<p>${i}) ${mediumText}</p>`,
       scrollToIndex: { index, position },
     })}
   </div>`;

--- a/packages/lit-virtualizer/test/test.js
+++ b/packages/lit-virtualizer/test/test.js
@@ -24,10 +24,10 @@ describe('scroll', function () {
     document.body.removeChild(container);
   })
 
-  it('uses the template to render the items', async function () {
+  it('uses the provided method to render items', async function () {
     const dir = scroll({
       items: ['foo', 'bar', 'baz'],
-      template: (item) => html`<p>${item}</p>`,
+      renderItem: (item) => html`<p>${item}</p>`,
       useShadowDOM: false
     });
     const templateResult = html`<div>
@@ -49,7 +49,7 @@ describe('scroll', function () {
     it('renders to shadow DOM when useShadowDOM is true', async function() {
       const dir = scroll({
         items: ['foo', 'bar', 'baz'],
-        template: (item) => html`<p>${item}</p>`,
+        renderItem: (item) => html`<p>${item}</p>`,
         useShadowDOM: true,
       });
       const templateResult = html`${dir}`
@@ -64,7 +64,7 @@ describe('scroll', function () {
     it('does not render to shadow DOM when useShadowDOM is false', async function() {
       const dir = scroll({
         items: ['foo', 'bar', 'baz'],
-        template: (item) => html`<p>${item}</p>`,
+        renderItem: (item) => html`<p>${item}</p>`,
         useShadowDOM: false,
       });
       const templateResult = html`${dir}`

--- a/packages/uni-virtualizer-examples/public/basic-lit-element/index.js
+++ b/packages/uni-virtualizer-examples/public/basic-lit-element/index.js
@@ -63,7 +63,7 @@ class ContactList extends LitElement {
         this.data = await resp.json();
     }
 
-    _contactTemplate(contact) {
+    _renderContact(contact) {
         return html`
             <contact-card .contact=${contact}></contact-card>
         `;
@@ -75,7 +75,7 @@ class ContactList extends LitElement {
             <lit-virtualizer
                 layout='vertical'
                 .items=${this.data}
-                .template=${this._contactTemplate}>
+                .renderItem=${this._renderContact}>
             </lit-virtualizer>
         `;
     }

--- a/packages/uni-virtualizer-examples/public/basic-lit-html/index.js
+++ b/packages/uni-virtualizer-examples/public/basic-lit-html/index.js
@@ -5,7 +5,7 @@ const example = (contacts) => html`
     <section>
         ${scroll({
             items: contacts,
-            template: ({ mediumText }) => html`<p>${mediumText}</p>`,
+            renderItem: ({ mediumText }) => html`<p>${mediumText}</p>`,
             scrollTarget: window,
             useShadowDOM: false
         })}

--- a/packages/uni-virtualizer-examples/public/scroll-to-index-lit-element/index.js
+++ b/packages/uni-virtualizer-examples/public/scroll-to-index-lit-element/index.js
@@ -7,7 +7,7 @@ let virtualizer;
     virtualizer = document.createElement('lit-virtualizer');
     const contacts = await(await fetch('../shared/contacts.json')).json();
     virtualizer.items = contacts;
-    virtualizer.template = ({ longText }, i) => html`<p>${i}) ${longText}</p>`;
+    virtualizer.renderItem = ({ longText }, i) => html`<p>${i}) ${longText}</p>`;
     document.body.appendChild(virtualizer);
 
     window.virtualizer = virtualizer;

--- a/packages/uni-virtualizer-examples/public/scroll-to-index-lit-html/index.js
+++ b/packages/uni-virtualizer-examples/public/scroll-to-index-lit-html/index.js
@@ -5,7 +5,7 @@ const example = (contacts, scrollToIndex = null) => html`
     <section style="height: 100%;">
         ${scroll({
             items: contacts,
-            template: ({ longText }, i) => html`<p>${i}) ${longText}</p>`,
+            renderItem: ({ longText }, i) => html`<p>${i}) ${longText}</p>`,
             scrollToIndex: scrollToIndex,
         })}
     </section>

--- a/packages/uni-virtualizer-examples/public/temp/index.js
+++ b/packages/uni-virtualizer-examples/public/temp/index.js
@@ -95,7 +95,7 @@ class Yo extends LitElement {
                 layout='vertical'
                 .scrollTarget=${window}
                 .items=${this.data}
-                .template=${contact => html`
+                .renderItem=${contact => html`
                     <wrapped-contact .contact=${contact}></wrapped-contact>
                 `}>
             </lit-virtualizer>


### PR DESCRIPTION
`template` is an overloaded term, and therefore confusing as an API option. Calling it `renderItem` allows the developer to separate the concept of "rendering a virtual item".

`renderItem` is a good name because it consumes the `items` list. So, there is a natural pairing between the two names.

closes #14