### PR TITLE
Add example of calculating first/last visible index.

### DIFF
--- a/packages/uni-virtualizer-examples/public/first-visible-index/index.html
+++ b/packages/uni-virtualizer-examples/public/first-visible-index/index.html
@@ -1,0 +1,43 @@
+<!--
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<!doctype html>
+<html>
+    <head>
+        <script src="../shared/boot.js"></script>
+        <style>
+          body, html {
+            height: 100%;
+            margin: 0;
+          }
+          body {
+            padding: 8px;
+            box-sizing: border-box;
+            display: flex;
+            flex-direction: column;
+            position: relative;
+          }
+          #controls {
+            margin: 10px 0;
+          }
+          #container {
+            flex: 1;
+          }
+        </style>
+      </head>
+      <body>
+        <div id="controls">
+          <button onclick="document.querySelector('#result').innerHTML = JSON.stringify(getVisibleIndices())">
+            Get visible indices
+          </button>
+          Result: <span id="result"></span>
+        </div>
+        <div id="container"></div>
+      </body>
+</html>

--- a/packages/uni-virtualizer-examples/public/first-visible-index/index.js
+++ b/packages/uni-virtualizer-examples/public/first-visible-index/index.js
@@ -1,0 +1,44 @@
+import { render, html } from 'lit-html';
+import { scroll } from 'lit-virtualizer/lib/scroll.js';
+
+const example = (contacts) => html`
+    <section style="height: 100%;">
+        ${scroll({
+            items: contacts,
+            template: ({ mediumText }, i) => 
+                html`<div data-i=${i} style="border-top: 3px solid blue; border-bottom: 3px dashed red; width: 100%;">${i}) ${mediumText}</div>`,
+            // scrollTarget: window,
+            useShadowDOM: true
+        })}
+    </section>
+`;
+
+(async function go() {
+    const contacts = await(await fetch('../shared/contacts.json')).json();
+    render(example(contacts), document.querySelector("#container"));
+})();
+
+window.getVisibleIndices = () => {
+    const virtualized = document.querySelector("section");
+    const children = virtualized.children;
+    const translateY = el => el.style.transform.match(/translate\(.*,\D*(\d+)px\)/)[1];
+    let first, last;
+    // The first child will always be a helper element that should be skipped.
+    for (let i = 1; i < children.length; i++) {
+        const child = children[i];
+        // Virtualized items are translated within the container. Get the translation value.
+        const childY = translateY(child);
+        // Some nodes are recycled for efficiency, and will have display: hidden
+        // until they are used. Skip them.
+        if (child.style.display === "hidden") {
+            continue;
+        }
+        if (childY <= virtualized.scrollTop) {
+            first = Number(child.dataset.i);
+        }
+        if (childY < virtualized.scrollTop + virtualized.clientHeight) {
+            last = Number(child.dataset.i);
+        }
+    }
+    return { first, last };
+}

--- a/packages/uni-virtualizer-examples/rollup.config.js
+++ b/packages/uni-virtualizer-examples/rollup.config.js
@@ -36,4 +36,14 @@ export default [
       resolve(),
     ]
   },
+  {
+    input: 'public/first-visible-index/index.js',
+    output: {
+      dir: 'public/first-visible-index/build',
+      format: 'esm'
+    },
+    plugins: [
+      resolve(),
+    ]
+  },
 ];


### PR DESCRIPTION
Draft for recommending a method of calculating first/last visible index without adding to the API.

See `window.getVisibleIndices`.

Approach: Pass the index argument of your template method to your node as a data attribute. Then, you can compare children transform and container scroll values to get the first visible index.