### PR TITLE
Add firstVisible and lastVisible to rangechange event

### DIFF
--- a/packages/lit-virtualizer/CHANGELOG.md
+++ b/packages/lit-virtualizer/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [Unreleased]
+### Added
+- `firstVisible` and `lastVisible` on `RangeChangeEvent`.
 
 ## [0.2.0] - 2019-07-15
 ### Added

--- a/packages/lit-virtualizer/README.md
+++ b/packages/lit-virtualizer/README.md
@@ -165,6 +165,37 @@ Optional. Scroll to the item at the give index. Place the item at the given posi
 
 Note: Rendering with `scrollToIndex` will cause the scroll view to fix at the given position until the user manually scrolls. If a lit-html template using the `scroll` directive is re-rendered, note that the view will be re-scrolled to respect the given `scrollToIndex` option. Take care to set or unset the `scrollToIndex` option upon subsequent re-renders for the desired behavior.
 
+### Events
+
+#### `rangechange` event
+
+Thi event is an instance of `RangeChangeEvent`, which has the following properties regarding the currently rendered range of items:
+
+* `first`: the index of the first item currently rendered. This may not be the first visible item.
+* `last`: the index of the last item currently rendered. This may not be the first visible item.
+* `firstVisible`: the index of the first item visible. That is, the first item to intersect the scroll view.
+* `lastVisible`: the index of the last item visible. That is, the last item to intersect the scroll view.
+
+This event is fired when any of these values change, e.g. because the user scrolled. To listen for this event, attach a listener to the host of the `scroll` directive. You can do this inline with lit-html.
+
+Example usage:
+
+```ts
+const handleEvent = (e) => {
+  console.log("The first visible index is", e.firstVisible);
+  console.log("The last visible index is", e.lastVisible);
+}
+
+const example = (contacts) => html`
+  <section @rangechange=${handleEvent}>
+    ${scroll({
+      items: contacts,
+      renderItem: ({ mediumText }) => html`<p>${mediumText}</p>`,
+    })}
+  </section>
+`;
+```
+
 ---
 
 ### `<lit-virtualizer>` element

--- a/packages/lit-virtualizer/src/lit-virtualizer.ts
+++ b/packages/lit-virtualizer/src/lit-virtualizer.ts
@@ -1,4 +1,4 @@
 export { repeat } from './lib/repeat';
 export { scroll } from './lib/scroll';
-export { Layout1d, Layout1dGrid } from './lib/uni-virtualizer/uni-virtualizer';
+export { Layout1d, Layout1dGrid, RangeChangeEvent } from './lib/uni-virtualizer/uni-virtualizer';
 export { LitVirtualizer } from './lib/lit-virtualizer';

--- a/packages/lit-virtualizer/test/test.js
+++ b/packages/lit-virtualizer/test/test.js
@@ -78,4 +78,35 @@ describe('scroll', function () {
       document.body.removeChild(container);
     });
   })
+
+  describe('visible indices', function() {
+    it('emits visibleindiceschanged events with the proper indices', async function() {
+      const directive = scroll({
+        items: ['foo', 'bar', 'baz', 'qux'],
+        renderItem: (item) => html`<div style='height: 50px'>${item}</div>`,
+        useShadowDOM: false,
+      });
+      container.style.height = '100px';
+      let firstVisible;
+      let lastVisible;
+      container.addEventListener('rangechange', e => {
+        firstVisible = e.firstVisible;
+        lastVisible = e.lastVisible;
+      });
+  
+      render(directive, container);
+  
+      await (new Promise(resolve => requestAnimationFrame(resolve)));
+      container.scrollTop = 50;
+      await (new Promise(resolve => requestAnimationFrame(resolve)));
+      assert.equal(firstVisible, 1);
+      assert.equal(lastVisible, 2);
+      container.scrollTop += 1;
+      await (new Promise(resolve => requestAnimationFrame(resolve)));
+      assert.equal(firstVisible, 1);
+      assert.equal(lastVisible, 3);
+
+      document.body.removeChild(container);
+    })
+  })
 });

--- a/packages/uni-virtualizer-examples/public/visible-indices-lit-element/index.html
+++ b/packages/uni-virtualizer-examples/public/visible-indices-lit-element/index.html
@@ -1,0 +1,40 @@
+<!--
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<!doctype html>
+<html>
+  <head>
+    <script src="../shared/boot.js"></script>
+    <style>
+      body, html {
+        height: 100%;
+        margin: 0;
+      }
+      body {
+        padding: 8px;
+        box-sizing: border-box;
+        display: flex;
+        flex-direction: column;
+        position: relative;
+      }
+      #results {
+        margin: 10px 0;
+      }
+      lit-virtualizer {
+        flex: 1;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="results">
+      First Visible: <span id="first-visible"></span>
+      Last Visible: <span id="last-visible"></span>
+    </div>
+  </body>
+</html>

--- a/packages/uni-virtualizer-examples/public/visible-indices-lit-element/index.js
+++ b/packages/uni-virtualizer-examples/public/visible-indices-lit-element/index.js
@@ -1,0 +1,22 @@
+import { html } from 'lit-html';
+import 'lit-virtualizer/lib/lit-virtualizer.js';
+
+const firstVisibleResult = document.querySelector("#first-visible");
+const lastVisibleResult = document.querySelector("#last-visible");
+const handleRangeChange = (e) => {
+    firstVisibleResult.innerHTML = e.firstVisible;
+    lastVisibleResult.innerHTML = e.lastVisible;
+}
+
+let virtualizer;
+
+(async function go() {
+    virtualizer = document.createElement('lit-virtualizer');
+    const contacts = await(await fetch('../shared/contacts.json')).json();
+    virtualizer.items = contacts;
+    virtualizer.renderItem = ({ mediumText }, i) =>
+        html`<div style="border-top: 3px solid blue; border-bottom: 3px dashed red; width: 100%;">${i}) ${mediumText}</div>`;
+    document.body.appendChild(virtualizer);
+
+    virtualizer.addEventListener("rangechange", handleRangeChange);
+})();

--- a/packages/uni-virtualizer-examples/public/visible-indices-lit-html/index.html
+++ b/packages/uni-virtualizer-examples/public/visible-indices-lit-html/index.html
@@ -1,0 +1,41 @@
+<!--
+@license
+Copyright (c) 2017 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<!doctype html>
+<html>
+  <head>
+    <script src="../shared/boot.js"></script>
+    <style>
+      body, html {
+        height: 100%;
+        margin: 0;
+      }
+      body {
+        padding: 8px;
+        box-sizing: border-box;
+        display: flex;
+        flex-direction: column;
+        position: relative;
+      }
+      #results {
+        margin: 10px 0;
+      }
+      #container {
+        flex: 1;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="results">
+      First Visible: <span id="first-visible"></span>
+      Last Visible: <span id="last-visible"></span>
+    </div>
+    <div id="container"></div>
+  </body>
+</html>

--- a/packages/uni-virtualizer-examples/public/visible-indices-lit-html/index.js
+++ b/packages/uni-virtualizer-examples/public/visible-indices-lit-html/index.js
@@ -1,0 +1,26 @@
+import { render, html } from 'lit-html';
+import { scroll } from 'lit-virtualizer/lib/scroll.js';
+
+
+const firstVisibleResult = document.querySelector("#first-visible");
+const lastVisibleResult = document.querySelector("#last-visible");
+const handleRangeChange = (e) => {
+    firstVisibleResult.innerHTML = e.firstVisible;
+    lastVisibleResult.innerHTML = e.lastVisible;
+}
+
+const example = (contacts) => html`
+    <section @rangechange=${handleRangeChange} style="height: 100%;">
+        ${scroll({
+            items: contacts,
+            renderItem: ({ mediumText }, i) =>
+                html`<div style="border-top: 3px solid blue; border-bottom: 3px dashed red; width: 100%;">${i}) ${mediumText}</div>`,
+            useShadowDOM: true
+        })}
+    </section>
+`;
+
+(async function go() {
+    const contacts = await(await fetch('../shared/contacts.json')).json();
+    render(example(contacts), document.querySelector("#container"));
+})();

--- a/packages/uni-virtualizer-examples/rollup.config.js
+++ b/packages/uni-virtualizer-examples/rollup.config.js
@@ -56,4 +56,24 @@ export default [
       resolve(),
     ]
   },
+  {
+    input: 'public/visible-indices-lit-html/index.js',
+    output: {
+      dir: 'public/visible-indices-lit-html/build',
+      format: 'esm'
+    },
+    plugins: [
+      resolve(),
+    ]
+  },
+  {
+    input: 'public/visible-indices-lit-element/index.js',
+    output: {
+      dir: 'public/visible-indices-lit-element/build',
+      format: 'esm'
+    },
+    plugins: [
+      resolve(),
+    ]
+  },
 ];

--- a/packages/uni-virtualizer/src/lib/layouts/Layout.ts
+++ b/packages/uni-virtualizer/src/lib/layouts/Layout.ts
@@ -59,14 +59,17 @@ export interface Layout {
    *       'height' | 'width': number
    *     }
    * - rangechange
-   *     Dispatch when the range of children that should be displayed changes,
-   *     based on layout calculations and the size of the container.
+   *     Dispatch when the range of children that should be displayed changes
+   *     (based on layout calculations and the size of the container) or when
+   *     the first or last item to intersect the container changes.
    *     detail: {
    *       first: number,
    *       last: number,
    *       num: number,
    *       stable: boolean,
-   *       remeasure: boolean
+   *       remeasure: boolean,
+   *       firstVisible: number,
+   *       lastVisible: number,
    *     }
    * - itempositionchange
    *     Dispatch when the child positions change, for example due to a range

--- a/packages/uni-virtualizer/src/lib/layouts/Layout1d.ts
+++ b/packages/uni-virtualizer/src/lib/layouts/Layout1d.ts
@@ -345,6 +345,7 @@ export class Layout1d extends Layout1dBase {
       this._emitScrollSize();
     }
 
+    this._updateVisibleIndices();
     this._emitRange();
     if (this._first === -1 && this._last === -1) {
       this._resetReflowState();

--- a/packages/uni-virtualizer/src/uni-virtualizer.ts
+++ b/packages/uni-virtualizer/src/uni-virtualizer.ts
@@ -1,5 +1,5 @@
 export { VirtualRepeater } from './lib/VirtualRepeater';
-export { VirtualScroller } from './lib/VirtualScroller';
+export { VirtualScroller, RangeChangeEvent } from './lib/VirtualScroller';
 
 export { Layout1d } from './lib/layouts/Layout1d';
 export { Layout1dGrid } from './lib/layouts/Layout1dGrid';


### PR DESCRIPTION
Add firstVisible and lastVisible to the rangechange event.

### Implementation notes
The first and last visible indices are calculated entirely in the Layout, similar to "range". They are checked and updated if necessary each time the Layout is informed of a new viewport scroll value.

Existing rangechange mechanism, for reference: The first and last visible indices are communicated to the VirtualScroller via the rangechange event. VirtualScroller, which has access to the DOM, then re-dispatches the event on the containing element.

### Open question
~We _could_ implement firstVisibleIndex and lastVisibleIndex as properties on `<lit-virtualizer>` by adding an event listener in its constructor by default. Yay or nay?~ We will let the user add an event listener if they so please.

closes #12 