### PR TITLE
Update dependency versions to allow installation

### DIFF
--- a/packages/lit-virtualizer/package.json
+++ b/packages/lit-virtualizer/package.json
@@ -43,8 +43,8 @@
     },
     "dependencies": {
         "event-target-shim": "^5.0.1",
-        "lit-element": "latest",
-        "lit-html": "latest",
+        "lit-element": "^1.0.0",
+        "lit-html": "^2.0.0",
         "resize-observer-polyfill": "^1.5.1",
         "rollup-plugin-filesize": "^6.1.1",
         "rollup-plugin-terser": "^5.0.0",


### PR DESCRIPTION
I'm trying to add `lit-virtualizer` as a dependency using `yarn` and get the following error:

```sh
$ yarn add lit-virtualizer
yarn add v1.17.3
[1/4] 🔍  Resolving packages...
warning lit-virtualizer > rollup-plugin-filesize > deep-assign@3.0.0: Check out `lodash.merge` or `merge-options` instead.
[2/4] 🚚  Fetching packages...
warning Pattern ["lit-html@latest"] is trying to unpack in the same destination "/Users/serhii/Library/Caches/Yarn/v4/npm-lit-html-1.1.2-2e3560a7075210243649c888ad738eaf0daa8374/node_modules/lit-html" as pattern ["lit-html@^1.0.0","lit-html@^1.1.2","lit-html@^1.0.0"]. This could result in non-deterministic behavior, skipping.
warning Pattern ["lit-element@latest"] is trying to unpack in the same destination "/Users/serhii/Library/Caches/Yarn/v4/npm-lit-element-2.2.1-79c94d8cfdc2d73b245656e37991bd1e4811d96f/node_modules/lit-element" as pattern ["lit-element@^2.2.1"]. This could result in non-deterministic behavior, skipping.
error brotli-size@4.0.0: The engine "node" is incompatible with this module. Expected version ">= 10.16.0". Got "10.14.0"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
```

I had to remove `lit-html` and `lit-element` dependencies from my `package.json` in order to get rid of this error. So let me suggest this change to avoid such problems.

@straversi PTAL