### PR TITLE
Add .js extension, correct uppercase

### DIFF
--- a/packages/lit-virtualizer/src/lib/lit-virtualizer.ts
+++ b/packages/lit-virtualizer/src/lib/lit-virtualizer.ts
@@ -1,5 +1,5 @@
 import { html, LitElement, customElement, property, TemplateResult } from 'lit-element';
-import { scroll } from './scroll';
+import { scroll } from './scroll.js';
 
 /**
  * A LitElement wrapper of the scroll directive.

--- a/packages/lit-virtualizer/src/lib/repeat.ts
+++ b/packages/lit-virtualizer/src/lib/repeat.ts
@@ -1,6 +1,6 @@
 import { directive, NodePart, createMarker, TemplateResult } from 'lit-html';
-import { VirtualRepeater } from './uni-virtualizer/lib/VirtualRepeater';
-import { Layout } from './uni-virtualizer/lib/layouts/Layout';
+import { VirtualRepeater } from './uni-virtualizer/lib/VirtualRepeater.js';
+import { Layout } from './uni-virtualizer/lib/layouts/Layout.js';
 
 /**
  * Mixin for VirtualRepeater and VirtualScroller. This mixin overrides the generic

--- a/packages/lit-virtualizer/src/lib/scroll.ts
+++ b/packages/lit-virtualizer/src/lib/scroll.ts
@@ -1,7 +1,7 @@
 import { directive, NodePart, TemplateResult } from 'lit-html';
-import { VirtualScroller } from './uni-virtualizer/lib/VirtualScroller';
-import { Layout } from './uni-virtualizer/lib/layouts/Layout';
-import { LitMixin } from './repeat';
+import { VirtualScroller } from './uni-virtualizer/lib/VirtualScroller.js';
+import { Layout } from './uni-virtualizer/lib/layouts/Layout.js';
+import { LitMixin } from './repeat.js';
 
 export class LitScroller<Item> extends LitMixin(VirtualScroller)<Item> {}
 

--- a/packages/lit-virtualizer/src/lit-virtualizer.ts
+++ b/packages/lit-virtualizer/src/lit-virtualizer.ts
@@ -1,4 +1,4 @@
-export { repeat } from './lib/repeat';
-export { scroll } from './lib/scroll';
-export { Layout1d, Layout1dGrid, RangeChangeEvent } from './lib/uni-virtualizer/uni-virtualizer';
-export { LitVirtualizer } from './lib/lit-virtualizer';
+export { repeat } from './lib/repeat.js';
+export { scroll } from './lib/scroll.js';
+export { Layout1d, Layout1dGrid, RangeChangeEvent } from './lib/uni-virtualizer/uni-virtualizer.js';
+export { LitVirtualizer } from './lib/lit-virtualizer.js';

--- a/packages/uni-virtualizer/src/lib/VirtualRepeater.ts
+++ b/packages/uni-virtualizer/src/lib/VirtualRepeater.ts
@@ -1,4 +1,4 @@
-import {ItemBox, Margins} from './layouts/Layout';
+import {ItemBox, Margins} from './layouts/Layout.js';
 
 export class VirtualRepeater<Item, Child extends Element, Key> {
   /**
@@ -75,7 +75,7 @@ export class VirtualRepeater<Item, Child extends Element, Key> {
    */
   protected _measureCallback: (sizes: {[key: number]: ItemBox}) => void = null;
 
-  /** 
+  /**
    * Number of children in the range. Set by num.
    * TODO @straversi: Consider renaming this. count? visibleElements?
    */

--- a/packages/uni-virtualizer/src/lib/VirtualScroller.ts
+++ b/packages/uni-virtualizer/src/lib/VirtualScroller.ts
@@ -1,6 +1,6 @@
-import {VirtualRepeater} from './VirtualRepeater';
+import {VirtualRepeater} from './VirtualRepeater.js';
 import getResizeObserver from './polyfillLoaders/ResizeObserver.js';
-import {Layout} from './layouts/Layout';
+import {Layout} from './layouts/Layout.js';
 
 const HOST_CLASSNAME = 'uni-virtualizer-host';
 let globalContainerStylesheet: HTMLStyleElement = null;

--- a/packages/uni-virtualizer/src/lib/layouts/Layout1d.ts
+++ b/packages/uni-virtualizer/src/lib/layouts/Layout1d.ts
@@ -1,5 +1,5 @@
-import {Layout1dBase} from './Layout1dBase';
-import {ItemBox, Positions, Size} from './Layout';
+import {Layout1dBase} from './Layout1dBase.js';
+import {ItemBox, Positions, Size} from './Layout.js';
 
 type ItemBounds = {
   pos: number,

--- a/packages/uni-virtualizer/src/lib/layouts/Layout1dBase.ts
+++ b/packages/uni-virtualizer/src/lib/layouts/Layout1dBase.ts
@@ -1,5 +1,5 @@
 import EventTarget from '../polyfillLoaders/EventTarget.js';
-import {Layout, ItemBox, Positions, ScrollDirection, Size, dimension, position} from './layout';
+import {Layout, ItemBox, Positions, ScrollDirection, Size, dimension, position} from './Layout.js';
 
 export abstract class Layout1dBase implements Layout {
   /**

--- a/packages/uni-virtualizer/src/lib/layouts/Layout1dGrid.ts
+++ b/packages/uni-virtualizer/src/lib/layouts/Layout1dGrid.ts
@@ -1,5 +1,5 @@
-import {Layout1dBase} from './Layout1dBase';
-import {ItemBox} from './Layout';
+import {Layout1dBase} from './Layout1dBase.js';
+import {ItemBox} from './Layout.js';
 
 /**
  * TODO @straversi: document and test this Layout.

--- a/packages/uni-virtualizer/src/uni-virtualizer.ts
+++ b/packages/uni-virtualizer/src/uni-virtualizer.ts
@@ -1,5 +1,5 @@
-export { VirtualRepeater } from './lib/VirtualRepeater';
-export { VirtualScroller, RangeChangeEvent } from './lib/VirtualScroller';
+export { VirtualRepeater } from './lib/VirtualRepeater.js';
+export { VirtualScroller, RangeChangeEvent } from './lib/VirtualScroller.js';
 
-export { Layout1d } from './lib/layouts/Layout1d';
-export { Layout1dGrid } from './lib/layouts/Layout1dGrid';
+export { Layout1d } from './lib/layouts/Layout1d.js';
+export { Layout1dGrid } from './lib/layouts/Layout1dGrid.js';


### PR DESCRIPTION
AFAIK, `lit-html` and `lit-element` use `.js` extension and TypeScript is able to resolve it.
So let's consider using it here as well for consistency and using in browser without tooling.

Also, there is one fix which is likely causing issues in certain case-sensitive environments:

```
ERROR in [at-loader] ./node_modules/lit-virtualizer/lib/uni-virtualizer/lib/layouts/Layout1dBase.d.ts:1:88 
    TS2307: Cannot find module './layout'.
```

This happens because of this line using `'./layout'` (should be `'./Layout'`):
https://github.com/PolymerLabs/uni-virtualizer/blob/f37c73b079d19c81d43f5cb6bff552e38087cb10/packages/uni-virtualizer/src/lib/layouts/Layout1dBase.ts#L2