### PR TITLE
Provide LitVirtualizer.js for side-effect-free imports

### DIFF
--- a/packages/lit-virtualizer/.gitignore
+++ b/packages/lit-virtualizer/.gitignore
@@ -13,4 +13,8 @@
 /virtualize.d.ts
 /virtualize.d.ts.map
 /virtualize.js.map
+/LitVirtualizer.js
+/LitVirtualizer.d.ts
+/LitVirtualizer.d.ts.map
+/LitVirtualizer.js.map
 /test/screenshot/cases/*/actual.*.png

--- a/packages/lit-virtualizer/CHANGELOG.md
+++ b/packages/lit-virtualizer/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.7.0-pre.3] - 2022-03-16
+### Changed
+- Extracted LitVirtualizer class to be imported without side-effects
+
 ## [0.6.0] - 2021-05-01
 - This is a stopgap release to unblock migrations to Lit 2.0
 - In the near future:

--- a/packages/lit-virtualizer/package.json
+++ b/packages/lit-virtualizer/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@lit-labs/virtualizer",
-    "version": "0.7.0-pre.2",
+    "version": "0.7.0-pre.3",
     "description": "Virtual scrolling for Lit",
     "author": "Google LLC",
     "license": "BSD-3-Clause",
@@ -45,7 +45,8 @@
         "/polyfills/resize-observer-polyfill/ResizeObserver.{d.ts,js}",
         "/lit-virtualizer.{d.ts,d.ts.map,js,js.map}",
         "/virtualize.{d.ts,d.ts.map,js,js.map}",
-        "/Virtualizer.{d.ts,d.ts.map,js,js.map}"
+        "/Virtualizer.{d.ts,d.ts.map,js,js.map}",
+        "/LitVirtualizer.{d.ts,d.ts.map,js,js.map}"
     ],
     "devDependencies": {
         "chai": "^4.2.0",

--- a/packages/lit-virtualizer/src/LitVirtualizer.ts
+++ b/packages/lit-virtualizer/src/LitVirtualizer.ts
@@ -1,0 +1,123 @@
+/**
+ * @license
+ * Copyright 2021 Google LLC
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+import { html, LitElement, TemplateResult } from 'lit';
+import { property } from 'lit/decorators/property.js';
+import { state } from 'lit/decorators/state.js';
+import { repeat } from 'lit/directives/repeat.js';
+import { Virtualizer, VirtualizerHostElement, virtualizerRef, RangeChangedEvent } from './Virtualizer.js';
+import { LayoutSpecifier, Layout, LayoutConstructor } from './layouts/shared/Layout.js';
+
+
+type RenderItemFunction = ((item: any, index: number) => TemplateResult)
+const defaultKeyFunction = (item: any) => item;
+const defaultRenderItem: RenderItemFunction = (item: any, idx: number) => html`${idx}: ${JSON.stringify(item, null, 2)}`;
+
+
+export class LitVirtualizer extends LitElement {
+    private _renderItem: RenderItemFunction = (item, idx) => defaultRenderItem(item, idx + this._first);
+    private _providedRenderItem: RenderItemFunction = defaultRenderItem;
+
+    set renderItem(fn: RenderItemFunction) {
+        this._providedRenderItem = fn;
+        this._renderItem = (item, idx) => fn(item, idx + this._first);
+        this.requestUpdate();
+    }
+
+    @property()
+    get renderItem() {
+        return this._providedRenderItem;
+    }
+
+    @property({attribute: false})
+    items: Array<unknown> = [];
+
+    @property({reflect: true, type: Boolean})
+    scroller = false;
+
+    @property()
+    keyFunction: ((item:unknown) => unknown) | undefined = defaultKeyFunction;
+
+    @state()
+    private _first = 0;
+
+    @state()
+    private _last = -1;
+
+    private _layout?: Layout | LayoutConstructor | LayoutSpecifier | null;
+
+    private _virtualizer?: Virtualizer;
+
+    @property({attribute:false})
+    set layout(layout: Layout | LayoutConstructor | LayoutSpecifier | null) {
+        this._layout = layout;
+        if (layout && this._virtualizer) {
+            this._virtualizer.layout = layout;
+        }
+    }
+
+    get layout(): Layout | LayoutConstructor | LayoutSpecifier | null {
+        return (this as VirtualizerHostElement)[virtualizerRef]!.layout;
+    }
+
+    /**
+     * Scroll to the specified index, placing that item at the given position
+     * in the scroll view.
+     */
+    scrollToIndex(index: number, position: string = 'start') {
+        this._virtualizer!.scrollToIndex = { index, position };
+    }
+
+    updated() {
+        if (this._virtualizer) {
+            if (this._layout !== undefined) {
+                this._virtualizer!.layout = this._layout;
+            }
+            this._virtualizer!.items = this.items;
+        }
+    }
+
+    firstUpdated() {
+        const hostElement = this;
+        const layout = this._layout;
+        this._virtualizer = new Virtualizer({ hostElement, layout, scroller: this.scroller });
+        hostElement.addEventListener('rangeChanged', (e: RangeChangedEvent) => {
+            e.stopPropagation();
+            this._first = e.first;
+            this._last = e.last;
+        });    
+        this._virtualizer!.connected();
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+        if (this._virtualizer) {
+            this._virtualizer.connected();
+        }
+    }
+
+    disconnectedCallback() {
+        if (this._virtualizer) {
+            this._virtualizer.disconnected();
+        }
+        super.disconnectedCallback();
+    }
+
+    createRenderRoot() {
+        return this;
+    }
+
+    render(): TemplateResult {
+        const { items, _renderItem, keyFunction } = this;
+        const itemsToRender = [];
+        if (this._first >= 0 && this._last >= this._first) {
+            for (let i = this._first; i < this._last + 1; i++) {
+                itemsToRender.push(items[i]);
+            }    
+        }
+        return repeat(itemsToRender, keyFunction || defaultKeyFunction, _renderItem) as TemplateResult;
+    }
+}

--- a/packages/lit-virtualizer/src/lit-virtualizer.ts
+++ b/packages/lit-virtualizer/src/lit-virtualizer.ts
@@ -4,127 +4,13 @@
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-import { html, LitElement, TemplateResult } from 'lit';
-import { customElement } from 'lit/decorators/custom-element.js';
-import { property } from 'lit/decorators/property.js';
-import { state } from 'lit/decorators/state.js';
-import { repeat } from 'lit/directives/repeat.js';
-import { Virtualizer, VirtualizerHostElement, virtualizerRef, RangeChangedEvent } from './Virtualizer.js';
-import { LayoutSpecifier, Layout, LayoutConstructor } from './layouts/shared/Layout.js';
-
-
-type RenderItemFunction = ((item: any, index: number) => TemplateResult)
-const defaultKeyFunction = (item: any) => item;
-const defaultRenderItem: RenderItemFunction = (item: any, idx: number) => html`${idx}: ${JSON.stringify(item, null, 2)}`;
+import { LitVirtualizer } from './LitVirtualizer.js';
+export { LitVirtualizer };
 
 /**
  * Import this module to declare the lit-virtualizer custom element.
  */
-@customElement('lit-virtualizer')
-export class LitVirtualizer extends LitElement {
-    private _renderItem: RenderItemFunction = (item, idx) => defaultRenderItem(item, idx + this._first);
-    private _providedRenderItem: RenderItemFunction = defaultRenderItem;
-
-    set renderItem(fn: RenderItemFunction) {
-        this._providedRenderItem = fn;
-        this._renderItem = (item, idx) => fn(item, idx + this._first);
-        this.requestUpdate();
-    }
-
-    @property()
-    get renderItem() {
-        return this._providedRenderItem;
-    }
-
-    @property({attribute: false})
-    items: Array<unknown> = [];
-
-    @property({reflect: true, type: Boolean})
-    scroller = false;
-
-    @property()
-    keyFunction: ((item:unknown) => unknown) | undefined = defaultKeyFunction;
-
-    @state()
-    private _first = 0;
-
-    @state()
-    private _last = -1;
-
-    private _layout?: Layout | LayoutConstructor | LayoutSpecifier | null;
-
-    private _virtualizer?: Virtualizer;
-  
-    @property({attribute:false})
-    set layout(layout: Layout | LayoutConstructor | LayoutSpecifier | null) {
-        this._layout = layout;
-        if (layout && this._virtualizer) {
-            this._virtualizer.layout = layout;
-        }
-    }
-
-    get layout(): Layout | LayoutConstructor | LayoutSpecifier | null {
-        return (this as VirtualizerHostElement)[virtualizerRef]!.layout;
-    }
-
-    /**
-     * Scroll to the specified index, placing that item at the given position
-     * in the scroll view.
-     */
-    scrollToIndex(index: number, position: string = 'start') {
-        this._virtualizer!.scrollToIndex = { index, position };
-    }
-
-    updated() {
-        if (this._virtualizer) {
-            if (this._layout !== undefined) {
-                this._virtualizer!.layout = this._layout;
-            }
-            this._virtualizer!.items = this.items;
-        }
-    }
-
-    firstUpdated() {
-        const hostElement = this;
-        const layout = this._layout;
-        this._virtualizer = new Virtualizer({ hostElement, layout, scroller: this.scroller });
-        hostElement.addEventListener('rangeChanged', (e: RangeChangedEvent) => {
-            e.stopPropagation();
-            this._first = e.first;
-            this._last = e.last;
-        });    
-        this._virtualizer!.connected();
-    }
-
-    connectedCallback() {
-        super.connectedCallback();
-        if (this._virtualizer) {
-            this._virtualizer.connected();
-        }
-    }
-
-    disconnectedCallback() {
-        if (this._virtualizer) {
-            this._virtualizer.disconnected();
-        }
-        super.disconnectedCallback();
-    }
-
-    createRenderRoot() {
-        return this;
-    }
-
-    render(): TemplateResult {
-        const { items, _renderItem, keyFunction } = this;
-        const itemsToRender = [];
-        if (this._first >= 0 && this._last >= this._first) {
-            for (let i = this._first; i < this._last + 1; i++) {
-                itemsToRender.push(items[i]);
-            }    
-        }
-        return repeat(itemsToRender, keyFunction || defaultKeyFunction, _renderItem) as TemplateResult;
-    }
-}
+customElements.define('lit-virtualizer', LitVirtualizer);
 
 declare global {
     interface HTMLElementTagNameMap {


### PR DESCRIPTION
Currently, any component using `LitVirtualizer` must also implicitly define `<lit-virtualizer>` in the global `customElements` registry.

This attempts to maintain backwards-compatibility with current behaviors, where `import { LitVirtualizer} from  '@lit-labs/virtualizer'` auto-registers the element, while adding a side-effect-free `import { LitVirtualizer } from '@lit-labs/virtualizer/LitVirtualizer.js'`.

I'm not sure if this really accomplishes that, though, because:

- The tests don't seem to be runnable.
- The build step creates the files I would expect (including `LitVirtualizer.js`) but I don't see any information on how this package is published.

Changes & feedback welcome. My goal is to make it possible to extend `LitVirtualizer` without modifying the global `customElements` registry.