### PR TITLE
Improvements during handoff

### DIFF
--- a/packages/lit-virtualizer-examples/public/stacked/index.js
+++ b/packages/lit-virtualizer-examples/public/stacked/index.js
@@ -11,8 +11,8 @@ export class StackTest extends LitElement {
     static get properties() {
         return {
             data1: { state: true },
-            data1: { state: true },
-            data1: { state: true }
+            data2: { state: true },
+            data3: { state: true }
         }
     }
 
@@ -49,7 +49,9 @@ export class StackTest extends LitElement {
 
     constructor() {
         super();
-        this.data = [];
+        this.data1 = [];
+        this.data2 = [];
+        this.data3 = [];
         this.renderItem = this.renderItem.bind(this);
     }
 

--- a/packages/lit-virtualizer/src/Virtualizer.ts
+++ b/packages/lit-virtualizer/src/Virtualizer.ts
@@ -60,9 +60,10 @@ export interface VirtualizerHostElement extends HTMLElement {
   [virtualizerRef]?: Virtualizer
 }
 
-type VerticalScrollSize = {height: number};
-type HorizontalScrollSize = {width: number};
-type ScrollSize = VerticalScrollSize | HorizontalScrollSize;
+type ScrollSize = {
+  height: number | null,
+  width: number | null
+}
 
 type ChildMeasurements = {[key: number]: ItemBox};
 
@@ -604,8 +605,8 @@ export class Virtualizer {
     // a certain size, so we clamp it here (this value based on ad hoc
     // testing in Chrome / Safari / Firefox Mac)
     const max = 8200000;
-    const h = size && (size as HorizontalScrollSize).width ? Math.min(max, (size as HorizontalScrollSize).width) : 0;
-    const v = size && (size as VerticalScrollSize).height ? Math.min(max, (size as VerticalScrollSize).height) : 0;
+    const h = size && size.width !== null ? Math.min(max, size.width) : 0;
+    const v = size && size.height !== null ? Math.min(max, size.height) : 0;
 
     if (this._isScroller) {
       this._getSizer().style.transform = `translate(${h}px, ${v}px)`;

--- a/packages/lit-virtualizer/src/Virtualizer.ts
+++ b/packages/lit-virtualizer/src/Virtualizer.ts
@@ -14,7 +14,6 @@ interface InternalRange {
   first: number;
   last: number;
   num: number;
-  remeasure: boolean;
   stable: boolean;
   firstVisible: number;
   lastVisible: number;
@@ -710,7 +709,6 @@ export class Virtualizer {
   // a first-class feature?
 
   private _childLoaded() {
-    // this.requestRemeasure();
   }
 
   // This is the callback for the ResizeObserver that watches the

--- a/packages/lit-virtualizer/src/Virtualizer.ts
+++ b/packages/lit-virtualizer/src/Virtualizer.ts
@@ -60,7 +60,7 @@ export interface VirtualizerHostElement extends HTMLElement {
   [virtualizerRef]?: Virtualizer
 }
 
-type ScrollSize = {
+interface ScrollSize {
   height: number | null,
   width: number | null
 }

--- a/packages/lit-virtualizer/src/Virtualizer.ts
+++ b/packages/lit-virtualizer/src/Virtualizer.ts
@@ -14,7 +14,6 @@ interface InternalRange {
   first: number;
   last: number;
   num: number;
-  stable: boolean;
   firstVisible: number;
   lastVisible: number;
 }

--- a/packages/lit-virtualizer/src/layouts/flow.ts
+++ b/packages/lit-virtualizer/src/layouts/flow.ts
@@ -145,11 +145,6 @@ export class FlowLayout extends BaseLayout<BaseLayoutConfig> {
    */
   _stable = true;
 
-  /**
-   * Whether to remeasure children during the next reflow.
-   */
-  _needsRemeasure = false;
-
   private _measureChildren = true;
 
   _estimate = true;
@@ -460,9 +455,7 @@ export class FlowLayout extends BaseLayout<BaseLayoutConfig> {
     this._emitRange();
     if (this._first === -1 && this._last === -1) {
       this._resetReflowState();
-    } else if (
-        this._first !== _first || this._last !== _last ||
-        this._needsRemeasure) {
+    } else if (this._first !== _first || this._last !== _last) {
       this._emitChildPositions();
       this._emitScrollError();
     } else {
@@ -514,14 +507,11 @@ export class FlowLayout extends BaseLayout<BaseLayoutConfig> {
   }
 
   _viewDim2Changed() {
-    this._needsRemeasure = true;
     this._scheduleReflow();
   }
 
   _emitRange() {
-    const remeasure = this._needsRemeasure;
     const stable = this._stable;
-    this._needsRemeasure = false;
-    super._emitRange({remeasure, stable});
+    super._emitRange({stable});
   }
 }

--- a/packages/lit-virtualizer/src/layouts/flow.ts
+++ b/packages/lit-virtualizer/src/layouts/flow.ts
@@ -402,7 +402,7 @@ export class FlowLayout extends BaseLayout<BaseLayoutConfig> {
       const pos = this._physicalMax;
       items.set(this._last, {pos, size});
       this._physicalMax += size + margin;
-      if (this._stable === false && this._estimate === false) {
+      if (!this._stable && !this._estimate) {
         break;
       }
     }

--- a/packages/lit-virtualizer/src/layouts/flow.ts
+++ b/packages/lit-virtualizer/src/layouts/flow.ts
@@ -370,8 +370,8 @@ export class FlowLayout extends BaseLayout<BaseLayoutConfig> {
     items.set(this._anchorIdx, {pos: this._anchorPos, size: anchorSize});
 
     this._first = (this._last = this._anchorIdx);
-    this._physicalMin = this._anchorPos;
-    this._physicalMax = this._anchorPos + anchorSize;
+    this._physicalMin = this._anchorPos - anchorLeadingMargin;
+    this._physicalMax = this._anchorPos + anchorSize + anchorTrailingMargin;
 
     while (this._physicalMin > lower && this._first > 0) {
       let size = this._getSize(--this._first);
@@ -379,33 +379,34 @@ export class FlowLayout extends BaseLayout<BaseLayoutConfig> {
         this._stable = false;
         size = this._getAverageSize();
       }
-      let margin = this._metricsCache.getMarginSize(this._first + 1);
+      let margin = this._metricsCache.getMarginSize(this._first);
       if (margin === undefined) {
         this._stable = false;
         margin = this._metricsCache.averageMarginSize;
       }
-      this._physicalMin -= size + margin;
+      this._physicalMin -= size;
       const pos = this._physicalMin;
       items.set(this._first, {pos, size});
+      this._physicalMin -= margin;
       if (this._stable === false && this._estimate === false) {
         break;
       }
     }
 
     while (this._physicalMax < upper && this._last < this._totalItems - 1) {
-      let margin = this._metricsCache.getMarginSize(++this._last);
-      if (margin === undefined) {
-        this._stable = false;
-        margin = this._metricsCache.averageMarginSize;
-      }
-      let size = this._getSize(this._last);
+      let size = this._getSize(++this._last);
       if (size === undefined) {
         this._stable = false;
         size = this._getAverageSize();
       }
-      const pos = this._physicalMax + margin;
+      let margin = this._metricsCache.getMarginSize(this._last);
+      if (margin === undefined) {
+        this._stable = false;
+        margin = this._metricsCache.averageMarginSize;
+      }
+      const pos = this._physicalMax;
       items.set(this._last, {pos, size});
-      this._physicalMax += margin + size;
+      this._physicalMax += size + margin;
       if (this._stable === false && this._estimate === false) {
         break;
       }
@@ -430,13 +431,12 @@ export class FlowLayout extends BaseLayout<BaseLayoutConfig> {
   }
 
   _calculateError(): number {
-    const { averageMarginSize } = this._metricsCache;
     if (this._first === 0) {
-      return this._physicalMin - (this._metricsCache.getMarginSize(0) ?? averageMarginSize);
+      return this._physicalMin;
     } else if (this._physicalMin <= 0) {
       return this._physicalMin - (this._first * this._delta);
     } else if (this._last === this._totalItems - 1) {
-      return (this._physicalMax + (this._metricsCache.getMarginSize(this._totalItems) ?? averageMarginSize)) - this._scrollSize;
+      return this._physicalMax - this._scrollSize;
     } else if (this._physicalMax >= this._scrollSize) {
       return (
           (this._physicalMax - this._scrollSize) +

--- a/packages/lit-virtualizer/src/layouts/flow.ts
+++ b/packages/lit-virtualizer/src/layouts/flow.ts
@@ -509,9 +509,4 @@ export class FlowLayout extends BaseLayout<BaseLayoutConfig> {
   _viewDim2Changed() {
     this._scheduleReflow();
   }
-
-  _emitRange() {
-    const stable = this._stable;
-    super._emitRange({stable});
-  }
 }

--- a/packages/lit-virtualizer/src/layouts/shared/BaseLayout.ts
+++ b/packages/lit-virtualizer/src/layouts/shared/BaseLayout.ts
@@ -409,6 +409,7 @@ export abstract class BaseLayout<C extends BaseLayoutConfig> implements Layout {
   protected _emitScrollSize() {
     const detail = {
       [this._sizeDim]: this._scrollSize,
+      [this._secondarySizeDim]: null
     };
     this.dispatchEvent(new CustomEvent('scrollsizechange', {detail}));
   }

--- a/packages/lit-virtualizer/src/layouts/shared/BaseLayout.ts
+++ b/packages/lit-virtualizer/src/layouts/shared/BaseLayout.ts
@@ -399,7 +399,6 @@ export abstract class BaseLayout<C extends BaseLayoutConfig> implements Layout {
           first: this._first,
           last: this._last,
           num: this._num,
-          stable: true,
           firstVisible: this._firstVisible,
           lastVisible: this._lastVisible,
         },


### PR DESCRIPTION
Miscellaneous fixes and clean-up, best reviewed commit-by-commit.

https://github.com/PolymerLabs/uni-virtualizer/pull/134/commits/b47f28aebbad103b78b53c59c5328cc2f25fed98: Fixes issues with two samples

https://github.com/PolymerLabs/uni-virtualizer/pull/134/commits/52f089ea0e79acfc727906a7d3df324a8c6e5e52: Fixes https://github.com/PolymerLabs/uni-virtualizer/issues/139

https://github.com/PolymerLabs/uni-virtualizer/pull/134/commits/815d4585097818c3c5d65bace4e3ec3513859718 & https://github.com/PolymerLabs/uni-virtualizer/pull/134/commits/9f8c541d9708967898ef651139d2afd9222d8726: Remove vestigial code

https://github.com/PolymerLabs/uni-virtualizer/pull/134/commits/9dd0bf249cf574c23cda6ce2420faf30f5edd6c1: Virtualizer is conceptually intended to support both 1D virtualization (horizontal or vertical) or 2D (both horizontal and vertical, a la Google Maps). We don’t yet have any layouts that virtualize in 2D, but this change in the way a layout reports its estimated size is made with such layouts in mind.

https://github.com/PolymerLabs/uni-virtualizer/pull/134/commits/ec9ca60f8650d3fa40ea01affe9e9a0b73178144: Addresses feedback on style